### PR TITLE
Replace linked list with VecDeque

### DIFF
--- a/src/job.rs
+++ b/src/job.rs
@@ -283,13 +283,8 @@ impl JobQueue {
     }
 
     pub fn pop_front(&mut self) -> Option<Job> {
-        let val = self.0.pop_front();
-        let job = match val {
-            // SAFETY:
-            // `Job` is still alive as per contract in `push_back`
-            Some(j) => unsafe { j.as_ref() },
-            None => return None,
-        };
+        let val = self.0.pop_front()?;
+        let job = unsafe { val.as_ref() };
         job.is_in_queue.set(false);
         job.fut_or_next
             .set(Some(Box::leak(Box::new(Future::default())).into()));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -383,7 +383,7 @@ impl<'s> Scope<'s> {
 
         let rb = b(self);
 
-        if job.is_in_queue() {
+        if job.is_waiting() {
             // SAFETY:
             // `job` is alive until the end of this scope and there has been no
             // other pop up to this point.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -330,10 +330,7 @@ impl<'s> Scope<'s> {
 
         let time = lock.time;
         if let Entry::Vacant(e) = lock.shared_jobs.entry(self.heartbeat_id()) {
-            // SAFETY:
-            // Any `Job` previously pushed onto the queue will be waited upon
-            // and will be alive until that point.
-            if let Some(job) = unsafe { self.job_queue.pop_front() } {
+            if let Some(job) = self.job_queue.pop_front() {
                 e.insert((time, job));
 
                 lock.time += 1;
@@ -384,12 +381,7 @@ impl<'s> Scope<'s> {
         let rb = b(self);
 
         if job.is_waiting() {
-            // SAFETY:
-            // `job` is alive until the end of this scope and there has been no
-            // other pop up to this point.
-            unsafe {
-                self.job_queue.pop_back();
-            }
+            self.job_queue.pop_back();
 
             // SAFETY:
             // Since the `job` was popped from the back of the queue, it cannot


### PR DESCRIPTION
Hey :)
I was looking around out of curiosity and found a nice place to reduce the amount of unsafety. This PR replaces Linked List-y structure of `JobQueue` with Rust's own `VecDeque`. As far as I can tell, there is no difference in performance (~1% difference on my machine). Also:

1. It is easier to read.
2. Tests for the queue are not needed anymore, since there is no reason to test `VecDeque`.
3. Since there is no sentinel value, `pop_back` and `pop_front` are safe.