### PR TITLE
Make dependencies used only in benchmarks dev-dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.81.0
       - uses: Swatinem/rust-cache@v2
-      - run: cargo check --all --no-default-features
-      - run: cargo check --all --all-features
+      - run: cargo check --all
 
   test:
     name: Test
@@ -24,8 +23,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.81.0
       - uses: Swatinem/rust-cache@v2
-      - run: cargo test --all --no-default-features
-      - run: cargo test --all --all-features
+      - run: cargo test --all
 
   fmt:
     name: Rustfmt
@@ -46,8 +44,7 @@ jobs:
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2
-      - run: cargo clippy --all --no-default-features -- -D warnings
-      - run: cargo clippy --all --all-features -- -D warnings
+      - run: cargo clippy --all
 
   miri:
     name: Miri

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,14 +11,10 @@ categories = ["concurrency"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 
-[features]
-bench = ["dep:divan", "dep:rayon"]
-
-[dependencies]
-divan = { version = "0.1.14", optional = true }
-rayon = { version = "1.10.0", optional = true }
+[dev-dependencies]
+divan = "0.1.14"
+rayon = "1.10.0"
 
 [[bench]]
 name = "overhead"
 harness = false
-required-features = ["bench"]


### PR DESCRIPTION
Optional features must be more about crate itself.