### PR TITLE
Remove send requirements on join methods

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -343,10 +343,8 @@ impl<'s> Scope<'s> {
 
     fn join_seq<A, B, RA, RB>(&mut self, a: A, b: B) -> (RA, RB)
     where
-        A: FnOnce(&mut Scope<'_>) -> RA + Send,
-        B: FnOnce(&mut Scope<'_>) -> RB + Send,
-        RA: Send,
-        RB: Send,
+        A: FnOnce(&mut Scope<'_>) -> RA,
+        B: FnOnce(&mut Scope<'_>) -> RB,
     {
         let rb = b(self);
         let ra = a(self);
@@ -357,9 +355,8 @@ impl<'s> Scope<'s> {
     fn join_heartbeat<A, B, RA, RB>(&mut self, a: A, b: B) -> (RA, RB)
     where
         A: FnOnce(&mut Scope<'_>) -> RA + Send,
-        B: FnOnce(&mut Scope<'_>) -> RB + Send,
+        B: FnOnce(&mut Scope<'_>) -> RB,
         RA: Send,
-        RB: Send,
     {
         let a = move |scope: &mut Scope<'_>| {
             if scope.heartbeat.load(Ordering::Relaxed) {
@@ -424,9 +421,8 @@ impl<'s> Scope<'s> {
     pub fn join<A, B, RA, RB>(&mut self, a: A, b: B) -> (RA, RB)
     where
         A: FnOnce(&mut Scope<'_>) -> RA + Send,
-        B: FnOnce(&mut Scope<'_>) -> RB + Send,
+        B: FnOnce(&mut Scope<'_>) -> RB,
         RA: Send,
-        RB: Send,
     {
         self.join_with_heartbeat_every::<64, _, _, _, _>(a, b)
     }
@@ -457,9 +453,8 @@ impl<'s> Scope<'s> {
     ) -> (RA, RB)
     where
         A: FnOnce(&mut Scope<'_>) -> RA + Send,
-        B: FnOnce(&mut Scope<'_>) -> RB + Send,
+        B: FnOnce(&mut Scope<'_>) -> RB,
         RA: Send,
-        RB: Send,
     {
         self.join_count = self.join_count.wrapping_add(1) % TIMES;
 


### PR DESCRIPTION
Before merging please consider that rayon's join would (usually) execute first closure on the same thread while the second one is scheduled to be potentially run on other threads. As such I think it would be better to swap those for Chili as well.