### PR TITLE
Move heartbeat before doing any work.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -361,14 +361,6 @@ impl<'s> Scope<'s> {
         RA: Send,
         RB: Send,
     {
-        let a = move |scope: &mut Scope<'_>| {
-            if scope.heartbeat.load(Ordering::Relaxed) {
-                scope.heartbeat();
-            }
-
-            a(scope)
-        };
-
         let stack = JobStack::new(a);
         let job = Job::new(&stack);
 
@@ -376,6 +368,10 @@ impl<'s> Scope<'s> {
         // `job` is alive until the end of this scope.
         unsafe {
             self.job_queue.push_back(&job);
+        }
+
+        if self.heartbeat.load(Ordering::Relaxed) {
+            self.heartbeat();
         }
 
         let rb = b(self);


### PR DESCRIPTION
Scope::join_heartbeat was starting to execute one of the closures before calling Scope::heartbeat, which meant that only subsequent recursive calls using the same scope would be able to take advantage of parallelism.

This patch moves that call before executing any of the closures in order to give way to parallelism even in case where only two closures are run from the root.